### PR TITLE
Add unit tests for YouTube helper scripts

### DIFF
--- a/scripts/test_fetch_youtube_refresh_token.py
+++ b/scripts/test_fetch_youtube_refresh_token.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+from unittest import mock
+
+# Allow importing from repository root
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from scripts.fetch_youtube_refresh_token import fetch_refresh_token
+
+
+def test_fetch_refresh_token():
+    mock_flow = mock.Mock()
+    mock_creds = mock.Mock(refresh_token="tok")
+    mock_flow.run_console.return_value = mock_creds
+
+    with mock.patch("scripts.fetch_youtube_refresh_token.InstalledAppFlow") as flow_cls:
+        flow_cls.from_client_config.return_value = mock_flow
+        token = fetch_refresh_token("id", "secret")
+
+    flow_cls.from_client_config.assert_called_once()
+    mock_flow.run_console.assert_called_once_with()
+    assert token == "tok"

--- a/scripts/test_upload_to_youtube.py
+++ b/scripts/test_upload_to_youtube.py
@@ -1,0 +1,66 @@
+import sys
+from pathlib import Path
+from unittest import mock
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from scripts.upload_to_youtube import get_authenticated_service, upload_video
+
+
+def test_get_authenticated_service_uses_refresh_token_env(monkeypatch):
+    monkeypatch.setenv("YOUTUBE_CLIENT_ID", "cid")
+    monkeypatch.setenv("YOUTUBE_CLIENT_SECRET", "secret")
+    monkeypatch.setenv("YOUTUBE_REFRESH_TOKEN", "tok")
+
+    with mock.patch("scripts.upload_to_youtube.build") as build_mock:
+        service = get_authenticated_service()
+
+    build_mock.assert_called_once()
+    assert service == build_mock.return_value
+
+
+def test_upload_video(monkeypatch):
+    class DummyRequest:
+        def __init__(self):
+            self.calls = 0
+        def next_chunk(self):
+            self.calls += 1
+            if self.calls == 1:
+                class Status:
+                    def progress(self):
+                        return 0.5
+                return Status(), None
+            return None, {"id": "123"}
+
+    dummy_insert = mock.Mock(return_value=DummyRequest())
+    dummy_videos = mock.Mock(insert=dummy_insert)
+    youtube_service = mock.Mock(videos=mock.Mock(return_value=dummy_videos))
+
+    monkeypatch.setattr(
+        "scripts.upload_to_youtube.MediaFileUpload",
+        lambda *a, **k: mock.Mock(),
+    )
+
+    response = upload_video(
+        youtube_service,
+        Path("/tmp/video.mp4"),
+        "title",
+        "desc",
+        ["t1"],
+    )
+
+    assert response == {"id": "123"}
+    dummy_insert.assert_called_once()
+
+def test_get_authenticated_service_triggers_oauth(monkeypatch):
+    monkeypatch.setenv("YOUTUBE_CLIENT_ID", "cid")
+    monkeypatch.setenv("YOUTUBE_CLIENT_SECRET", "secret")
+    monkeypatch.delenv("YOUTUBE_REFRESH_TOKEN", raising=False)
+
+    with mock.patch("scripts.upload_to_youtube.fetch_refresh_token", return_value="tok") as fetch_mock, \
+         mock.patch("scripts.upload_to_youtube.build") as build_mock:
+        service = get_authenticated_service()
+
+    fetch_mock.assert_called_once_with("cid", "secret")
+    build_mock.assert_called_once()
+    assert service == build_mock.return_value


### PR DESCRIPTION
## Summary
- add tests next to scripts for YouTube authentication helper
- test uploading logic in `upload_to_youtube`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68772784763083319cf72c7ec90ef281