### PR TITLE
Enhance project generation with trending topics

### DIFF
--- a/scripts/generate_project.py
+++ b/scripts/generate_project.py
@@ -1,43 +1,67 @@
 #!/usr/bin/env python3
-"""Generate a complete content project from research to video upload."""
+"""Generate a content project based on trending search topics."""
 
 from __future__ import annotations
 
 import argparse
 from datetime import datetime
 from pathlib import Path
+import urllib.request
+import xml.etree.ElementTree as ET
 
 from generate_content import create_project
 
 
+def fetch_trending_topics() -> list[str]:
+    """Return a list of trending search topics in the US."""
+    url = (
+        "https://trends.google.com/trends/trendingsearches/daily/rss?geo=US"
+    )
+    try:
+        with urllib.request.urlopen(url, timeout=10) as resp:
+            data = resp.read()
+    except Exception as exc:  # pragma: no cover - network may fail
+        print(f"Failed to fetch trending topics: {exc}")
+        return []
+
+    root = ET.fromstring(data)
+    return [item.findtext("title") for item in root.findall(".//item")]
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Run the full content creation pipeline for a topic"
+        description="Gather trending topics and create a project folder",
     )
-    parser.add_argument("topic", help="Topic to research and generate content about")
+    parser.add_argument(
+        "topic",
+        nargs="?",
+        default="Trending topics",
+        help="Optional topic to include in the project",
+    )
     args = parser.parse_args()
 
-    slug = datetime.now().strftime("%Y%m%d-%H%M%S")
+    slug = datetime.now().strftime("%Y-%m-%d")
     project_dir = create_project(slug)
+
+    topics = fetch_trending_topics()
 
     references = project_dir / "references.md"
     references.write_text(f"Sources gathered about {args.topic}\n")
 
     manuscript = project_dir / "manuscript.md"
-    manuscript.write_text(
-        f"# Manuscript about {args.topic}\n\nThis document cites sources listed in references.md."
-    )
+    manuscript_lines = ["# Trending Topics", ""]
+    if topics:
+        manuscript_lines += [f"- {t}" for t in topics]
+    else:
+        manuscript_lines.append("No trending topics found.")
+    manuscript.write_text("\n".join(manuscript_lines))
 
-    video_script = project_dir / "video_script.md"
-    video_script.write_text(
-        "Screen by screen breakdown aligned with the manuscript for Sora video generation."
-    )
+    timestamps = project_dir / "video_timestamps.txt"
+    ts_lines = []
+    for idx, title in enumerate(topics, start=0):
+        ts_lines.append(f"00:{idx:02d}:00 - {title}")
+    timestamps.write_text("\n".join(ts_lines))
 
-    video_file = project_dir / "output.mp4"
-    video_file.touch()
-
-    print(f"Generated video placeholder at {video_file}")
-    print(f"Would upload {video_file} to YouTube using upload_to_youtube.py")
     print(f"Project created at {project_dir}")
 
 

--- a/tests/test_generate_project.py
+++ b/tests/test_generate_project.py
@@ -1,0 +1,44 @@
+import sys
+import argparse
+from datetime import datetime
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from scripts import generate_project as gp
+
+
+def test_fetch_trending_topics(monkeypatch):
+    sample_rss = """
+    <rss><channel>
+        <item><title>Topic1</title></item>
+        <item><title>Topic2</title></item>
+    </channel></rss>
+    """
+
+    class DummyResp:
+        def __init__(self, text):
+            self.text = text.encode()
+        def read(self):
+            return self.text
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    monkeypatch.setattr(gp.urllib.request, "urlopen", lambda *a, **k: DummyResp(sample_rss))
+    topics = gp.fetch_trending_topics()
+    assert topics == ["Topic1", "Topic2"]
+
+
+def test_main_creates_files(monkeypatch, tmp_path):
+    monkeypatch.setattr(gp, "fetch_trending_topics", lambda: ["A", "B"])
+    monkeypatch.setattr(gp, "create_project", lambda slug: tmp_path)
+    monkeypatch.setattr(
+        gp.argparse.ArgumentParser,
+        "parse_args",
+        lambda self: argparse.Namespace(topic="t"),
+    )
+    gp.main()
+    assert (tmp_path / "manuscript.md").exists()
+    assert (tmp_path / "video_timestamps.txt").exists()


### PR DESCRIPTION
## Summary
- update `generate_project.py` to fetch US trending searches
- create manuscript and timestamp files based on those topics
- add tests for new functionality

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6877ccc764a88331a8c30f04b7037232