### PR TITLE
Fix YouTube SSL certificate error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,6 @@ google-api-python-client
 google-auth
 google-auth-oauthlib
 
+certifi
+
 pytest-cov

--- a/scripts/upload_to_youtube.py
+++ b/scripts/upload_to_youtube.py
@@ -1,7 +1,11 @@
 """Upload a video to YouTube using the YouTube Data API v3."""
 
-import argparse
 import os
+import certifi
+
+os.environ["SSL_CERT_FILE"] = certifi.where()
+
+import argparse
 from pathlib import Path
 from typing import List
 


### PR DESCRIPTION
## Summary
- ensure YouTube uploader uses certifi's trusted CA bundle
- include certifi in requirements

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6879790719848331919400fcedd7cdee