### PR TITLE
Allow optional SSL verification for YouTube upload

### DIFF
--- a/scripts/upload_to_youtube.py
+++ b/scripts/upload_to_youtube.py
@@ -14,6 +14,7 @@ from fetch_youtube_refresh_token import fetch_refresh_token
 from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
 from googleapiclient.http import MediaFileUpload
+from httplib2 import Http
 
 # Scope required for uploading videos
 YOUTUBE_UPLOAD_SCOPE = "https://www.googleapis.com/auth/youtube.upload"
@@ -46,7 +47,11 @@ def get_authenticated_service() -> any:
         client_secret=client_secret,
         scopes=[YOUTUBE_UPLOAD_SCOPE],
     )
-    return build("youtube", "v3", credentials=creds)
+
+    disable_verify = os.environ.get("DISABLE_SSL_VERIFY", "false").lower() == "true"
+    http_client = Http(disable_ssl_certificate_validation=True) if disable_verify else None
+
+    return build("youtube", "v3", credentials=creds, http=http_client)
 
 
 def upload_video(


### PR DESCRIPTION
## Summary
- allow the uploader to use an HTTP client that disables SSL verification when the `DISABLE_SSL_VERIFY` env var is set

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68798a8724c08331b5f3e89103145044